### PR TITLE
Add `--theme={auto,light,dark}` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "mdopen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64",
  "bus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdopen"
 edition = "2021"
-version = "0.5.0"
+version = "0.6.0"
 description = "Preview markdown files in a browser"
 keywords = ["markdown"]
 license = "BSD-3-Clause"

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -1,9 +1,12 @@
 #![allow(unused)]
 use std::net::SocketAddr;
 
+use crate::cli::Theme;
+
 pub(crate) struct AppConfig {
     pub addr: SocketAddr,
     pub enable_reload: bool,
     pub enable_latex: bool,
     pub enable_syntax_highlight: bool,
+    pub theme: Theme,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,23 @@ use lexopt::{
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const USAGE: &str = include_str!("cli_help.txt");
 
+#[derive(Debug, Clone, Copy)]
+pub enum Theme {
+    Auto,
+    Light,
+    Dark,
+}
+
+impl Theme {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Theme::Auto => "auto",
+            Theme::Light => "light",
+            Theme::Dark => "dark",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct CommandArgs {
     pub files: Vec<String>,
@@ -17,6 +34,7 @@ pub struct CommandArgs {
     pub enable_reload: bool,
     pub enable_latex: bool,
     pub enable_syntax_highlight: bool,
+    pub theme: Theme,
 }
 
 impl CommandArgs {
@@ -40,6 +58,7 @@ fn parse_args() -> Result<CommandArgs, lexopt::Error> {
         enable_latex: true,
         enable_reload: false,
         enable_syntax_highlight: true,
+        theme: Theme::Auto,
     };
 
     let mut parser = lexopt::Parser::from_env();
@@ -84,6 +103,20 @@ fn parse_args() -> Result<CommandArgs, lexopt::Error> {
             }
             Long("no-syntax-hl") => {
                 args.enable_syntax_highlight = false;
+            }
+            Long("theme") => {
+                let val: String = parser.value()?.parse()?;
+                args.theme = match val.as_str() {
+                    "auto" => Theme::Auto,
+                    "light" => Theme::Light,
+                    "dark" => Theme::Dark,
+                    other => {
+                        return Err(lexopt::Error::ParsingFailed {
+                            value: other.into(),
+                            error: "expected one of: auto, light, dark".into(),
+                        })
+                    }
+                };
             }
             Value(val) => {
                 if cfg!(not(feature = "syntax")) {

--- a/src/cli_help.txt
+++ b/src/cli_help.txt
@@ -29,3 +29,7 @@ Options:
         Controls if mdopen will include syntax highlighting script for
         code blocks in HTML.
         Default: true
+    --theme=VALUE
+        Color theme for the rendered preview.
+        VALUE: auto | light | dark
+        Default: auto (follows the browser's prefers-color-scheme)

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ fn get_contents(path: &Path, config: &AppConfig, jinja_env: &Environment) -> io:
                     markdown_body => body,
                     enable_latex => config.enable_latex,
                     enable_reload => cfg!(feature = "reload") && config.enable_reload,
+                    theme => config.theme.as_str(),
                 })
                 .unwrap();
             html.into()
@@ -254,6 +255,7 @@ fn main() {
         enable_reload: args.enable_reload,
         enable_latex: args.enable_latex,
         enable_syntax_highlight: args.enable_syntax_highlight,
+        theme: args.theme,
     };
 
     let server = match Server::http(config.addr) {

--- a/src/template/page.html
+++ b/src/template/page.html
@@ -5,11 +5,17 @@
 {{ super() }}
 <link rel="stylesheet" href="{{style_url}}">
 <style>
+{% if theme == "dark" %}
+body { background-color: #0d1117; }
+{% elif theme == "light" %}
+body { background-color: #ffffff; }
+{% else %}
 @media (prefers-color-scheme: dark) {
     body {
         background-color: #0d1117;
     }
 }
+{% endif %}
 .markdown-body {
     box-sizing: border-box;
     min-width: 200px;
@@ -21,7 +27,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="markdown-body">
+<div class="markdown-body"{% if theme != "auto" %} data-theme="{{theme}}"{% endif %}>
     {# <p><a href='#' onclick='history.back();'>Go back</a></p> #}
     {# <p><a href='/'>Home</a></p> #}
     {{markdown_body|safe}}

--- a/src/vendor/github.css
+++ b/src/vendor/github.css
@@ -11,7 +11,7 @@
   --fgColor-accent: Highlight;
 }
 @media (prefers-color-scheme: dark) {
-  .markdown-body, [data-theme="dark"] {
+  .markdown-body:not([data-theme="light"]) {
     /* dark */
     color-scheme: dark;
     --focus-outlineColor: #1f6feb;
@@ -67,7 +67,7 @@
   }
 }
 @media (prefers-color-scheme: light) {
-  .markdown-body, [data-theme="light"] {
+  .markdown-body:not([data-theme="dark"]) {
     /* light */
     color-scheme: light;
     --focus-outlineColor: #0969da;
@@ -121,6 +121,112 @@
     --color-prettylights-syntax-meta-diff-range: #8250df;
     --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
   }
+}
+[data-theme="dark"] {
+  color-scheme: dark;
+  --focus-outlineColor: #1f6feb;
+  --fgColor-default: #f0f6fc;
+  --fgColor-muted: #9198a1;
+  --fgColor-accent: #4493f8;
+  --fgColor-success: #3fb950;
+  --fgColor-attention: #d29922;
+  --fgColor-danger: #f85149;
+  --fgColor-done: #ab7df8;
+  --bgColor-default: #0d1117;
+  --bgColor-muted: #151b23;
+  --bgColor-neutral-muted: #656c7633;
+  --bgColor-attention-muted: #bb800926;
+  --borderColor-default: #3d444d;
+  --borderColor-muted: #3d444db3;
+  --borderColor-neutral-muted: #3d444db3;
+  --borderColor-accent-emphasis: #1f6feb;
+  --borderColor-success-emphasis: #238636;
+  --borderColor-attention-emphasis: #9e6a03;
+  --borderColor-danger-emphasis: #da3633;
+  --borderColor-done-emphasis: #8957e5;
+  --color-prettylights-syntax-comment: #9198a1;
+  --color-prettylights-syntax-constant: #79c0ff;
+  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+  --color-prettylights-syntax-entity: #d2a8ff;
+  --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
+  --color-prettylights-syntax-entity-tag: #7ee787;
+  --color-prettylights-syntax-keyword: #ff7b72;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-variable: #ffa657;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+  --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
+  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
+  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
+  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+  --color-prettylights-syntax-carriage-return-bg: #b62324;
+  --color-prettylights-syntax-string-regexp: #7ee787;
+  --color-prettylights-syntax-markup-list: #f2cc60;
+  --color-prettylights-syntax-markup-heading: #1f6feb;
+  --color-prettylights-syntax-markup-italic: #f0f6fc;
+  --color-prettylights-syntax-markup-bold: #f0f6fc;
+  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+  --color-prettylights-syntax-markup-deleted-bg: #67060c;
+  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+  --color-prettylights-syntax-markup-inserted-bg: #033a16;
+  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+  --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
+  --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+  --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+}
+[data-theme="light"] {
+  color-scheme: light;
+  --focus-outlineColor: #0969da;
+  --fgColor-default: #1f2328;
+  --fgColor-muted: #59636e;
+  --fgColor-accent: #0969da;
+  --fgColor-success: #1a7f37;
+  --fgColor-attention: #9a6700;
+  --fgColor-danger: #d1242f;
+  --fgColor-done: #8250df;
+  --bgColor-default: #ffffff;
+  --bgColor-muted: #f6f8fa;
+  --bgColor-neutral-muted: #818b981f;
+  --bgColor-attention-muted: #fff8c5;
+  --borderColor-default: #d1d9e0;
+  --borderColor-muted: #d1d9e0b3;
+  --borderColor-neutral-muted: #d1d9e0b3;
+  --borderColor-accent-emphasis: #0969da;
+  --borderColor-success-emphasis: #1a7f37;
+  --borderColor-attention-emphasis: #9a6700;
+  --borderColor-danger-emphasis: #cf222e;
+  --borderColor-done-emphasis: #8250df;
+  --color-prettylights-syntax-comment: #59636e;
+  --color-prettylights-syntax-constant: #0550ae;
+  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+  --color-prettylights-syntax-entity: #6639ba;
+  --color-prettylights-syntax-storage-modifier-import: #1f2328;
+  --color-prettylights-syntax-entity-tag: #0550ae;
+  --color-prettylights-syntax-keyword: #cf222e;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-variable: #953800;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
+  --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
+  --color-prettylights-syntax-invalid-illegal-bg: #82071e;
+  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+  --color-prettylights-syntax-carriage-return-bg: #cf222e;
+  --color-prettylights-syntax-string-regexp: #116329;
+  --color-prettylights-syntax-markup-list: #3b2300;
+  --color-prettylights-syntax-markup-heading: #0550ae;
+  --color-prettylights-syntax-markup-italic: #1f2328;
+  --color-prettylights-syntax-markup-bold: #1f2328;
+  --color-prettylights-syntax-markup-deleted-text: #82071e;
+  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+  --color-prettylights-syntax-markup-inserted-text: #116329;
+  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+  --color-prettylights-syntax-markup-changed-text: #953800;
+  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+  --color-prettylights-syntax-meta-diff-range: #8250df;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
 }
 
 .markdown-body {


### PR DESCRIPTION
Adds an explicit theme override so users (and tools driving mdopen, e.g. [grip-mode](https://github.com/seagle0128/grip-mode)) can force a theme regardless of the browser's `prefers-color-scheme`. Default `auto` preserves existing behavior:

```text
--theme=VALUE
     Color theme for the rendered preview.
     VALUE: auto | light | dark
     Default: auto (follows the browser's prefers-color-scheme)
```

Usage:
```bash 
mdopen --theme=light file.md
```